### PR TITLE
Change clock color to make more readable

### DIFF
--- a/styles/DesktopClock.scss
+++ b/styles/DesktopClock.scss
@@ -6,7 +6,7 @@ $bg-color: #{"@theme_bg_color"}; */
 .clock-container {
     font-weight: bold;
     font-family: Electroharmonix;
-    color: colors.$background;
+    color: colors.$foreground;
 }
 .clock-time {
     font-size: 100px;


### PR DESCRIPTION
 Set foreground from pywal instead of background as clock color to make it more readable